### PR TITLE
Proposal: date type instead of string

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -232,8 +232,7 @@ definitions:
         minLength: 1
         description: ProtocolloDSU
       dsu_created_at:
-        type: string
-        format: date
+        $ref: "https://raw.githubusercontent.com/pagopa/io-functions-commons/master/openapi/definitions.yaml#/Timestamp"
         description: DataPresentazioneDSU
       has_discrepancies:
         type: boolean


### PR DESCRIPTION
Should we use `Timestamp` type? 
The benefits I see are:
* uniformity with other date values
* it's been resolved as a `Date` by our code generator