### PR TITLE
using builder functions instead of constants

### DIFF
--- a/GetEligibilityCheck/handler.ts
+++ b/GetEligibilityCheck/handler.ts
@@ -19,11 +19,11 @@ import {
   ResponseSuccessJson
 } from "italia-ts-commons/lib/responses";
 import { FiscalCode } from "italia-ts-commons/lib/strings";
-import { eligibilityCheckOrchestratorSuffix } from "../EligibilityCheck/handler";
 import { EligibilityCheck } from "../generated/definitions/EligibilityCheck";
 import { EligibilityCheckModel } from "../models/eligibility_check";
 import { initTelemetryClient } from "../utils/appinsights";
 import { toApiEligibilityCheck } from "../utils/conversions";
+import { makeStartEligibilityCheckOrchestratorId } from "../utils/orchestrators";
 
 type IGetEligibilityCheckHandler = (
   context: Context,
@@ -45,7 +45,7 @@ export function GetEligibilityCheckHandler(
   return async (context, fiscalCode) => {
     const client = df.getClient(context);
     const status = await client.getStatus(
-      `${fiscalCode}${eligibilityCheckOrchestratorSuffix}`
+      makeStartEligibilityCheckOrchestratorId(fiscalCode)
     );
     if (status.customStatus === "RUNNING") {
       return ResponseSuccessAccepted("Still running");
@@ -75,7 +75,7 @@ export function GetEligibilityCheckHandler(
         // we stop the orchestrator here in order to avoid
         // sending a push notification with the same result
         await client.terminate(
-          `${fiscalCode}${eligibilityCheckOrchestratorSuffix}`,
+          makeStartEligibilityCheckOrchestratorId(fiscalCode),
           "Success"
         );
         return toApiEligibilityCheck(maybeModelEligibilityCheck.value).fold<

--- a/StartBonusActivation/handler.ts
+++ b/StartBonusActivation/handler.ts
@@ -16,6 +16,7 @@ import {
   ResponseSuccessAccepted
 } from "italia-ts-commons/lib/responses";
 import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { makeStartBonusActivationOrchestratorId } from "../utils/orchestrators";
 
 type IStartBonusActivationHandler = (
   context: Context,
@@ -29,14 +30,12 @@ type IStartBonusActivationHandler = (
   | IResponseErrorConflict
 >;
 
-export const activationOrchestratorSuffix = "-BV01ACTIVATION";
-
 export function StartBonusActivationHandler(): IStartBonusActivationHandler {
   return async (context, fiscalCode) => {
     // TODO: Add implementation
     const client = df.getClient(context);
     const status = await client.getStatus(
-      `${fiscalCode}${activationOrchestratorSuffix}`
+      makeStartBonusActivationOrchestratorId(fiscalCode)
     );
     if (status.runtimeStatus === df.OrchestrationRuntimeStatus.Running) {
       return ResponseSuccessAccepted();

--- a/utils/orchestrators.ts
+++ b/utils/orchestrators.ts
@@ -1,0 +1,17 @@
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+
+/**
+ * The identifier for StartBonusActivationOrchestrator
+ * @param fiscalCode the id of the requesting user
+ */
+export const makeStartBonusActivationOrchestratorId = (
+  fiscalCode: FiscalCode
+) => `${fiscalCode}-BV01ACTIVATION`;
+
+/**
+ * The identifier for StartEligibilityCheckOrchestrator
+ * @param fiscalCode the id of the requesting user
+ */
+export const makeStartEligibilityCheckOrchestratorId = (
+  fiscalCode: FiscalCode
+) => `${fiscalCode}-BV01DSU`;


### PR DESCRIPTION
I propose this refactor to introduce builder functions instead of constants for orchstrators' id generation. The supposed benefit is to have a centralised and more eloquent source of truth for those constants.