### PR TITLE
Convert MaxBonusAmount and MaxBonusTaxBenefit to enums

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  version: 1.1.0
+  version: 1.2.0
   title: IO Bonus API
   contact:
     name: IO team
@@ -219,14 +219,18 @@ definitions:
       - id
   MaxBonusAmount:
     description: Max bonus amount in euro
-    type: integer
-    minimum: 150
-    maximum: 500
+    type: string
+    x-extensible-enum:
+      - "EUR_150"
+      - "EUR_250"
+      - "EUR_500"
   MaxBonusTaxBenefit:
     description: Max bonus tax benefit in euro
-    type: integer
-    minimum: 30
-    maximum: 100
+    type: string
+    x-extensible-enum:
+      - "EUR_30"
+      - "EUR_50"
+      - "EUR_100"
   FamilyMember:
     type: object
     properties:

--- a/utils/__tests__/conversions.test.ts
+++ b/utils/__tests__/conversions.test.ts
@@ -42,14 +42,13 @@ import {
 } from "../../generated/definitions/EligibilityCheckSuccessIneligible";
 import { EligibilityCheck } from "../../generated/models/EligibilityCheck";
 
-import { IWithinRangeIntegerTag } from "italia-ts-commons/lib/numbers";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
 import { BonusVacanzaBase as ApiBonusVacanzaBase } from "../../generated/ade/BonusVacanzaBase";
 import { BonusActivationStatusEnum as ApiBonusActivationStatusEnum } from "../../generated/definitions/BonusActivationStatus";
 import { BonusCode as BonusCodeApi } from "../../generated/definitions/BonusCode";
-import { MaxBonusAmount } from "../../generated/definitions/MaxBonusAmount";
-import { MaxBonusTaxBenefit } from "../../generated/definitions/MaxBonusTaxBenefit";
+import { MaxBonusAmountEnum } from "../../generated/definitions/MaxBonusAmount";
+import { MaxBonusTaxBenefitEnum } from "../../generated/definitions/MaxBonusTaxBenefit";
 import { BonusActivationStatusEnum } from "../../generated/models/BonusActivationStatus";
 import { BonusCode as BonusCodeModel } from "../../generated/models/BonusCode";
 
@@ -70,8 +69,8 @@ const anElibigleApiObject: ApiEligibilityCheckSuccessEligible = {
     ],
     has_discrepancies: true,
     isee_type: "some isee type" as NonEmptyString,
-    max_amount: 200 as MaxBonusAmount,
-    max_tax_benefit: 50 as MaxBonusTaxBenefit,
+    max_amount: MaxBonusAmountEnum.EUR_250,
+    max_tax_benefit: MaxBonusTaxBenefitEnum.EUR_50,
     request_id: "123" as NonEmptyString
   },
   id: (aFiscalCode as unknown) as NonEmptyString,
@@ -106,8 +105,8 @@ const anEligibleDomainObject: EligibilityCheckSuccessEligible = {
     ],
     hasDiscrepancies: true,
     iseeType: "some isee type",
-    maxAmount: 200 as MaxBonusAmount,
-    maxTaxBenefit: 50 as MaxBonusTaxBenefit,
+    maxAmount: MaxBonusAmountEnum.EUR_250,
+    maxTaxBenefit: MaxBonusTaxBenefitEnum.EUR_50,
     requestId: "123" as NonEmptyString
   },
   id: (aFiscalCode as unknown) as NonEmptyString,
@@ -145,9 +144,9 @@ const aBonusActivationDomainObject: BonusActivation = {
       }
     ],
 
-    maxAmount: (200 as unknown) as IWithinRangeIntegerTag<150, 501> & number,
+    maxAmount: MaxBonusAmountEnum.EUR_250,
 
-    maxTaxBenefit: (100 as unknown) as IWithinRangeIntegerTag<30, 101> & number,
+    maxTaxBenefit: MaxBonusTaxBenefitEnum.EUR_50,
 
     requestId: "aRequestId" as NonEmptyString,
 
@@ -179,10 +178,9 @@ const aBonusActivationApiObject: ApiBonusActivation = {
       }
     ],
 
-    max_amount: (200 as unknown) as IWithinRangeIntegerTag<150, 501> & number,
+    max_amount: MaxBonusAmountEnum.EUR_250,
 
-    max_tax_benefit: (100 as unknown) as IWithinRangeIntegerTag<30, 101> &
-      number,
+    max_tax_benefit: MaxBonusTaxBenefitEnum.EUR_50,
 
     request_id: "aRequestId" as NonEmptyString,
 


### PR DESCRIPTION
Still need to fix tests, just wanted to share as preview.

Note that I had to prefix `EUR_` to the enums due to [this issue](https://github.com/Microsoft/TypeScript/issues/19438#issuecomment-338995518), and because of that we have to convert back strings like `EUR_150` to the number `150` where a number is expected (probably only when calling ADE).