### PR TITLE
[#173154240] review retry logic on ADE service

### DIFF
--- a/__mocks__/mocks.ts
+++ b/__mocks__/mocks.ts
@@ -30,6 +30,11 @@ import {
   RetrievedBonusLease
 } from "../models/bonus_lease";
 import { RetrievedUserBonus, UserBonus } from "../models/user_bonus";
+import { BonusVacanzaBase } from "../generated/ade/BonusVacanzaBase";
+import {
+  BonusVacanzaInvalidRequestError,
+  BonusVacanzaTransientError
+} from "../utils/adeClient";
 
 export const aFiscalCode = "AAABBB80A01C123D" as FiscalCode;
 export const anotherFiscalCode = "CCCDDD80A01C123D" as FiscalCode;
@@ -150,4 +155,33 @@ export const aRetrievedUserBonus: RetrievedUserBonus = {
   _ts: 123,
   id: (aUserBonus.bonusId as unknown) as NonEmptyString,
   kind: "IRetrievedUserBonus"
+};
+
+export const aBonusVacanzaBase: BonusVacanzaBase = {
+  codiceBuono: "ACEFGHLMNPRU",
+  codiceFiscaleDichiarante: "AAAAAA55A55A555A",
+  dataGenerazione: new Date("2020-06-11T08:54:31.143Z"),
+  flagDifformita: 1,
+  importoMassimo: 500,
+  mac: "123",
+  nucleoFamiliare: [
+    {
+      codiceFiscale: "AAAAAA55A55A555A"
+    },
+    {
+      codiceFiscale: "BBBBBB88B88B888B"
+    },
+    {
+      codiceFiscale: "CCCCCC99C99C999C"
+    }
+  ]
+};
+
+export const aBonusVacanzaInvalidRequestError: BonusVacanzaInvalidRequestError = {
+  errorCode: "1000",
+  errorMessage: "lorem ipsum"
+};
+export const aBonusVacanzaTransientError: BonusVacanzaTransientError = {
+  errorCode: "3000",
+  errorMessage: "Generic Error"
 };

--- a/__mocks__/mocks.ts
+++ b/__mocks__/mocks.ts
@@ -18,6 +18,7 @@ import {
   StatusEnum as EligibilityCheckSuccessIneligibleStatus
 } from "../generated/models/EligibilityCheckSuccessIneligible";
 
+import { BonusVacanzaBase } from "../generated/ade/BonusVacanzaBase";
 import { BonusActivationWithFamilyUID } from "../generated/models/BonusActivationWithFamilyUID";
 import { FamilyUID } from "../generated/models/FamilyUID";
 import {
@@ -30,7 +31,6 @@ import {
   RetrievedBonusLease
 } from "../models/bonus_lease";
 import { RetrievedUserBonus, UserBonus } from "../models/user_bonus";
-import { BonusVacanzaBase } from "../generated/ade/BonusVacanzaBase";
 import {
   BonusVacanzaInvalidRequestError,
   BonusVacanzaTransientError


### PR DESCRIPTION
Refactor the bonus request to ADE service to allow a retry for the following cases:
* any runtime error while connecting to the service (every time the client promise rejects)
* any timeout abort
* any response status mapped as transient by the ADE api spec

