### PR TITLE
[#173394178] DSU duration as variable

### DIFF
--- a/EligibilityCheckActivity/__tests__/handler.test.ts
+++ b/EligibilityCheckActivity/__tests__/handler.test.ts
@@ -1,6 +1,9 @@
+// tslint:disable: no-identical-functions
+
 import { right } from "fp-ts/lib/Either";
 import { fromEither } from "fp-ts/lib/TaskEither";
 import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { Hour, Millisecond } from "italia-ts-commons/lib/units";
 import { context } from "../../__mocks__/durable-functions";
 import {
   ConsultazioneSogliaIndicatoreResponse,
@@ -13,10 +16,6 @@ import {
   getEligibilityCheckActivityHandler
 } from "../handler";
 
-const mockConsultazioneSogliaIndicatore = jest.fn();
-const mockINPSSoapClient = ({
-  ConsultazioneSogliaIndicatore: mockConsultazioneSogliaIndicatore
-} as unknown) as ISoapClientAsync;
 const aFiscalCode = "AAABBB80A01C123D" as FiscalCode;
 
 const aINPSDsu: ConsultazioneSogliaIndicatoreResponse = {
@@ -34,12 +33,21 @@ const aINPSDsu: ConsultazioneSogliaIndicatoreResponse = {
   }
 };
 
+const mockConsultazioneSogliaIndicatore = jest.fn(() =>
+  fromEither(right(aINPSDsu))
+);
+const mockINPSSoapClient = ({
+  ConsultazioneSogliaIndicatore: mockConsultazioneSogliaIndicatore
+} as unknown) as ISoapClientAsync;
+
+const aDsuDuration = 24 as Hour;
+
 describe("EligibilityCheckActivity", () => {
   it("should retrieve a DSU from INPS SOAP web service", async () => {
-    mockConsultazioneSogliaIndicatore.mockImplementationOnce(() =>
-      fromEither(right(aINPSDsu))
+    const handler = getEligibilityCheckActivityHandler(
+      mockINPSSoapClient,
+      aDsuDuration
     );
-    const handler = getEligibilityCheckActivityHandler(mockINPSSoapClient);
 
     const response = await handler(context, aFiscalCode);
 
@@ -52,5 +60,76 @@ describe("EligibilityCheckActivity", () => {
     const decodedReponse = ActivityResultSuccess.decode(response);
 
     expect(decodedReponse.isRight()).toBeTruthy();
+  });
+
+  it("should calculate dsu duration from the provided value", async () => {
+    const dsuDuration = 24 as Hour;
+
+    const handler = getEligibilityCheckActivityHandler(
+      mockINPSSoapClient,
+      dsuDuration
+    );
+
+    const testExecutionTime = Date.now();
+    const response = await handler(context, aFiscalCode);
+
+    expect(mockConsultazioneSogliaIndicatore).toBeCalledWith({
+      CodiceFiscale: aFiscalCode,
+      CodiceSoglia: "BVAC01",
+      FornituraNucleo: SiNoTypeEnum.SI
+    });
+
+    ActivityResultSuccess.decode(response).fold(
+      _ => fail("should be a successful output"),
+      value => {
+        // consider some discrepancy when comparing dates as validBefore is calculated based on a timestamp captured slightly after testExecutionTime
+        const timeDelta = 50 as Millisecond;
+
+        // it must be a future date
+        expect(value.validBefore.getTime()).toBeGreaterThanOrEqual(
+          testExecutionTime
+        );
+        // it must correctly calculate validBefore
+        expect(value.validBefore.getTime()).toBeLessThanOrEqual(
+          // tslint:disable-next-line: restrict-plus-operands
+          testExecutionTime + dsuDuration * 60 * 60 * 1000 + timeDelta
+        );
+      }
+    );
+  });
+  it("should calculate dsu duration from the provided value with fractions of hour", async () => {
+    const dsuDuration = (1 / 3600) as Hour;
+
+    const handler = getEligibilityCheckActivityHandler(
+      mockINPSSoapClient,
+      dsuDuration
+    );
+
+    const testExecutionTime = Date.now();
+    const response = await handler(context, aFiscalCode);
+
+    expect(mockConsultazioneSogliaIndicatore).toBeCalledWith({
+      CodiceFiscale: aFiscalCode,
+      CodiceSoglia: "BVAC01",
+      FornituraNucleo: SiNoTypeEnum.SI
+    });
+
+    ActivityResultSuccess.decode(response).fold(
+      _ => fail("should be a successful output"),
+      value => {
+        // consider some discrepancy when comparing dates as validBefore is calculated based on a timestamp captured slightly after testExecutionTime
+        const timeDelta = 50 as Millisecond;
+
+        // it must be a future date
+        expect(value.validBefore.getTime()).toBeGreaterThanOrEqual(
+          testExecutionTime
+        );
+        // it must correctly calculate validBefore
+        expect(value.validBefore.getTime()).toBeLessThanOrEqual(
+          // tslint:disable-next-line: restrict-plus-operands
+          testExecutionTime + dsuDuration * 60 * 60 * 1000 + timeDelta
+        );
+      }
+    );
   });
 });

--- a/EligibilityCheckActivity/handler.ts
+++ b/EligibilityCheckActivity/handler.ts
@@ -1,6 +1,6 @@
 import { Context } from "@azure/functions";
 import { defaultClient } from "applicationinsights";
-import { addHours, addSeconds, addMilliseconds } from "date-fns";
+import { addMilliseconds } from "date-fns";
 import { fromEither } from "fp-ts/lib/TaskEither";
 import { FiscalCode } from "io-functions-commons/dist/generated/definitions/FiscalCode";
 import * as t from "io-ts";

--- a/EligibilityCheckActivity/index.ts
+++ b/EligibilityCheckActivity/index.ts
@@ -6,11 +6,11 @@ import { getEligibilityCheckActivityHandler } from "./handler";
 
 const INPS_SERVICE_ENDPOINT = getRequiredStringEnv("INPS_SERVICE_ENDPOINT");
 
-const DEFAULT_DSU_DURATION = 24;
+const DEFAULT_DSU_DURATION_H = 24;
 
 const dsuDuration = NumberFromString.decode(
   process.env.INPS_DSU_DURATION
-).getOrElse(DEFAULT_DSU_DURATION) as Hour;
+).getOrElse(DEFAULT_DSU_DURATION_H) as Hour;
 
 const soapClientAsync = createClient(INPS_SERVICE_ENDPOINT);
 

--- a/EligibilityCheckActivity/index.ts
+++ b/EligibilityCheckActivity/index.ts
@@ -1,12 +1,21 @@
 ﻿import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
+import { NumberFromString } from "italia-ts-commons/lib/numbers";
+import { Hour } from "italia-ts-commons/lib/units";
 import { createClient } from "../utils/inpsSoapClient";
 import { getEligibilityCheckActivityHandler } from "./handler";
 
 const INPS_SERVICE_ENDPOINT = getRequiredStringEnv("INPS_SERVICE_ENDPOINT");
 
+const DEFAULT_DSU_DURATION = 24;
+
+const dsuDuration = NumberFromString.decode(
+  process.env.INPS_DSU_DURATION
+).getOrElse(DEFAULT_DSU_DURATION) as Hour;
+
 const soapClientAsync = createClient(INPS_SERVICE_ENDPOINT);
 
 const eligibilityCheckActivityHandler = getEligibilityCheckActivityHandler(
-  soapClientAsync
+  soapClientAsync,
+  dsuDuration
 );
 export default eligibilityCheckActivityHandler;

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "io-functions-commons": "^10.5.0",
     "io-functions-express": "^0.1.0",
     "io-ts": "1.8.5",
-    "italia-ts-commons": "^8.4.1",
+    "italia-ts-commons": "^8.5.0",
     "node-fetch": "^2.6.0",
     "winston": "^3.2.1",
     "xmldom": "^0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4476,10 +4476,10 @@ italia-ts-commons@^7.0.1:
     node-fetch "^2.6.0"
     validator "^10.1.0"
 
-italia-ts-commons@^8.4.1:
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/italia-ts-commons/-/italia-ts-commons-8.4.1.tgz#6d8f5c09cd9d1041c389d154b8c1cd78d3e01e47"
-  integrity sha512-ryloFKHeXQRmF/7xoosT3mqGVhF5kyODIzh5q1mBsIHhrsPzCPuvU5n4JDPXJCBdvukKSq/Q6ngV9ZYNZm00VA==
+italia-ts-commons@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/italia-ts-commons/-/italia-ts-commons-8.5.0.tgz#9967ec1b94745f482d5cc942a1bacf7de6f6461b"
+  integrity sha512-pTX90/WW987t7pdcbQngCFm35c3gQlDFIUCnDZ6VCo5vNMl8VwdZztGIcYyEaJw6xMjb1WjSRlltnDdSe0B9Eg==
   dependencies:
     abort-controller "^3.0.0"
     agentkeepalive "^4.1.2"


### PR DESCRIPTION
Use an ENV variable to define de validity period of a DSU. Useful for testing.

### Env introduced

name | required | description | type | default
|-|-|-|-|-|
INPS_DSU_DURATION|no|duration of a DSU, in hours|number|24

### Usage
In the `.env` file
```bash
# one day
INPS_DSU_DURATION=24
# six minutes
INPS_DSU_DURATION=0.1
```
