### PR TITLE
[#173356449] Asynchronous processing of bonus activations

### DIFF
--- a/ContinueBonusActivation/__tests__/handler.test.ts
+++ b/ContinueBonusActivation/__tests__/handler.test.ts
@@ -1,0 +1,135 @@
+import * as df from "durable-functions";
+import { isLeft, isRight, left, right } from "fp-ts/lib/Either";
+import { none, some } from "fp-ts/lib/Option";
+import { context } from "../../__mocks__/durable-functions";
+import {
+  aBonusActivation,
+  aBonusActivationWithFamilyUID,
+  aBonusId,
+  aFiscalCode
+} from "../../__mocks__/mocks";
+import { BonusActivationStatusEnum } from "../../generated/models/BonusActivationStatus";
+import { BonusActivationModel } from "../../models/bonus_activation";
+import { ContinueBonusActivationHandler } from "../handler";
+
+describe("ContinueBonusActivation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should not activate bonus if status is not processing", async () => {
+    const mockBonusActivationkModel = ({
+      findBonusActivationForUser: jest.fn().mockImplementationOnce(async () =>
+        right(
+          some({
+            bonusActivation: {
+              ...aBonusActivation,
+              status: BonusActivationStatusEnum.ACTIVE
+            }
+          })
+        )
+      )
+    } as unknown) as BonusActivationModel;
+
+    const response = await ContinueBonusActivationHandler(
+      df.getClient(context),
+      mockBonusActivationkModel,
+      aFiscalCode,
+      aBonusId
+    ).run();
+
+    expect(isLeft(response)).toBeTruthy();
+    if (isLeft(response)) {
+      expect(response.value.kind).toEqual("PERMANENT");
+    }
+  });
+
+  it("should not activate bonus if querying for existing bonus throw", async () => {
+    const mockBonusActivationkModel = ({
+      findBonusActivationForUser: jest.fn().mockImplementationOnce(async () => {
+        throw new Error("foobar");
+      })
+    } as unknown) as BonusActivationModel;
+
+    const response = await ContinueBonusActivationHandler(
+      df.getClient(context),
+      mockBonusActivationkModel,
+      aFiscalCode,
+      aBonusId
+    ).run();
+
+    expect(isLeft(response)).toBeTruthy();
+    if (isLeft(response)) {
+      expect(response.value.kind).toEqual("PERMANENT");
+      expect(response.value.reason).toContain("foobar");
+    }
+  });
+
+  it("should not activate bonus if status is querying for bonus fail", async () => {
+    const mockBonusActivationkModel = ({
+      findBonusActivationForUser: jest
+        .fn()
+        .mockImplementationOnce(async () => left({ code: 500, body: "foobar" }))
+    } as unknown) as BonusActivationModel;
+
+    const response = await ContinueBonusActivationHandler(
+      df.getClient(context),
+      mockBonusActivationkModel,
+      aFiscalCode,
+      aBonusId
+    ).run();
+
+    expect(isLeft(response)).toBeTruthy();
+    if (isLeft(response)) {
+      expect(response.value.kind).toEqual("PERMANENT");
+      expect(response.value.reason).toContain("foobar");
+    }
+  });
+
+  it("should not activate bonus if an existing bonus is not found", async () => {
+    const mockBonusActivationkModel = ({
+      findBonusActivationForUser: jest
+        .fn()
+        .mockImplementationOnce(async () => right(none))
+    } as unknown) as BonusActivationModel;
+
+    const response = await ContinueBonusActivationHandler(
+      df.getClient(context),
+      mockBonusActivationkModel,
+      aFiscalCode,
+      aBonusId
+    ).run();
+
+    expect(isLeft(response)).toBeTruthy();
+    if (isLeft(response)) {
+      expect(response.value.kind).toEqual("PERMANENT");
+    }
+  });
+
+  it("should activate bonus if status is processing", async () => {
+    const mockBonusActivationkModel = ({
+      findBonusActivationForUser: jest.fn().mockImplementationOnce(async () =>
+        right(
+          some({
+            bonusActivation: {
+              ...aBonusActivationWithFamilyUID,
+              status: BonusActivationStatusEnum.PROCESSING
+            }
+          })
+        )
+      )
+    } as unknown) as BonusActivationModel;
+
+    const response = await ContinueBonusActivationHandler(
+      df.getClient(context),
+      mockBonusActivationkModel,
+      aFiscalCode,
+      aBonusId
+    ).run();
+
+    expect(isRight(response)).toBeTruthy();
+    if (isRight(response)) {
+      expect(response.value).toEqual("instanceId");
+    }
+  });
+});

--- a/ContinueBonusActivation/function.json
+++ b/ContinueBonusActivation/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "bonusActivation",
+      "queueName": "bonusactivations",
+      "connection":"BONUS_STORAGE_CONNECTION_STRING"
+    },
+    {
+      "name": "starter",
+      "type": "durableClient",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/ContinueBonusActivation/index.js"
+}

--- a/ContinueBonusActivation/handler.ts
+++ b/ContinueBonusActivation/handler.ts
@@ -1,0 +1,122 @@
+import { DurableOrchestrationClient } from "durable-functions/lib/src/classes";
+import { toError } from "fp-ts/lib/Either";
+import { toString } from "fp-ts/lib/function";
+import {
+  fromEither,
+  fromLeft,
+  fromPredicate,
+  taskEither,
+  TaskEither,
+  tryCatch
+} from "fp-ts/lib/TaskEither";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+
+import { OrchestratorInput } from "../StartBonusActivationOrchestrator/handler";
+
+import { BonusCode } from "../generated/definitions/BonusCode";
+import { BonusActivationWithFamilyUID } from "../generated/models/BonusActivationWithFamilyUID";
+import { BonusActivationModel } from "../models/bonus_activation";
+import { Failure } from "../utils/errors";
+import { makeStartBonusActivationOrchestratorId } from "../utils/orchestrators";
+
+/**
+ * Start a new instance of StartBonusActivationOrchestrator
+ *
+ * @param client an instance of durable function client
+ * @param bonusActivation a record of bonus activation
+ * @param fiscalCode the fiscal code of the requesting user. Needed to make a unique id for the orchestrator instance
+ *
+ * @returns either an internal error or the id of the created orchestrator
+ */
+const runStartBonusActivationOrchestrator = (
+  client: DurableOrchestrationClient,
+  bonusActivation: BonusActivationWithFamilyUID,
+  fiscalCode: FiscalCode
+): TaskEither<Failure, string> =>
+  fromEither(OrchestratorInput.decode({ bonusActivation }))
+    .mapLeft(err =>
+      // validate input here, so we can make the http handler fail too. This shouldn't happen anyway
+      Failure.encode({
+        kind: "PERMANENT",
+        reason: `Error validating orchestrator input: ${readableReport(err)}`
+      })
+    )
+    .chain(orchestratorInput =>
+      tryCatch(
+        () =>
+          client.startNew(
+            "StartBonusActivationOrchestrator",
+            makeStartBonusActivationOrchestratorId(fiscalCode),
+            orchestratorInput
+          ),
+        _ =>
+          Failure.encode({
+            kind: "TRANSIENT",
+            reason: `Error starting the orchestrator: ${toError(_).message}`
+          })
+      )
+    );
+
+/**
+ * Start the orchestrator for a pending (processing)
+ * bonus activation identified by its id (code)
+ * and the applicant fiscal code.
+ */
+export function ContinueBonusActivationHandler(
+  dfClient: DurableOrchestrationClient,
+  bonusActivationModel: BonusActivationModel,
+  fiscalCode: FiscalCode,
+  bonusId: BonusCode
+): TaskEither<Failure, string> {
+  return tryCatch(
+    () => bonusActivationModel.findBonusActivationForUser(bonusId, fiscalCode),
+    err =>
+      // Promise rejected or thrown
+      Failure.encode({
+        kind: "PERMANENT",
+        reason: `Query error: [${err}]`
+      })
+  )
+    .chain(_ =>
+      // CosmosDB query error
+      fromEither(_).mapLeft((
+        queryError // Promise rejected or thrown
+      ) =>
+        Failure.encode({
+          kind: "PERMANENT",
+          reason: `Query Error code=${queryError.code}`
+        })
+      )
+    )
+    .chain<BonusActivationWithFamilyUID>(maybeBonusActivation =>
+      maybeBonusActivation.fold(
+        fromLeft(
+          Failure.encode({
+            kind: "PERMANENT",
+            reason: "Bonus activation not found"
+          })
+        ),
+        _ => taskEither.of(_.bonusActivation)
+      )
+    )
+    .chain(
+      fromPredicate(
+        _ => _.status === "PROCESSING",
+        _ =>
+          Failure.encode({
+            kind: "PERMANENT",
+            reason: "Bonus activation status is not PROCESSING"
+          })
+      )
+    )
+    .foldTaskEither(
+      err => fromLeft(err),
+      bonusActivation =>
+        runStartBonusActivationOrchestrator(
+          dfClient,
+          bonusActivation,
+          fiscalCode
+        )
+    );
+}

--- a/ContinueBonusActivation/handler.ts
+++ b/ContinueBonusActivation/handler.ts
@@ -99,7 +99,7 @@ export function ContinueBonusActivationHandler(
     )
     .chain(
       fromPredicate(
-        _ => _.status === "PROCESSING",
+        bonusActivation => bonusActivation.status === "PROCESSING",
         _ =>
           Failure.encode({
             kind: "PERMANENT",

--- a/ContinueBonusActivation/handler.ts
+++ b/ContinueBonusActivation/handler.ts
@@ -79,9 +79,7 @@ export function ContinueBonusActivationHandler(
   )
     .chain(_ =>
       // CosmosDB query error
-      fromEither(_).mapLeft((
-        queryError // Promise rejected or thrown
-      ) =>
+      fromEither(_).mapLeft(queryError =>
         Failure.encode({
           kind: "PERMANENT",
           reason: `Query Error code=${queryError.code}`

--- a/ContinueBonusActivation/handler.ts
+++ b/ContinueBonusActivation/handler.ts
@@ -19,6 +19,11 @@ import { BonusActivationModel } from "../models/bonus_activation";
 import { Failure } from "../utils/errors";
 import { makeStartBonusActivationOrchestratorId } from "../utils/orchestrators";
 
+export const ContinueBonusActivationInput = t.type({
+  applicantFiscalCode: FiscalCode,
+  bonusId: BonusCode
+});
+
 /**
  * Start a new instance of StartBonusActivationOrchestrator
  *

--- a/ContinueBonusActivation/handler.ts
+++ b/ContinueBonusActivation/handler.ts
@@ -1,6 +1,5 @@
 import { DurableOrchestrationClient } from "durable-functions/lib/src/classes";
 import { toError } from "fp-ts/lib/Either";
-import { toString } from "fp-ts/lib/function";
 import {
   fromEither,
   fromLeft,

--- a/ContinueBonusActivation/handler.ts
+++ b/ContinueBonusActivation/handler.ts
@@ -81,7 +81,7 @@ export function ContinueBonusActivationHandler(
       // Promise rejected or thrown
       Failure.encode({
         kind: "PERMANENT",
-        reason: `Query error: [${err}]`
+        reason: `Query error: ${err}`
       })
   )
     .chain(_ =>
@@ -89,7 +89,7 @@ export function ContinueBonusActivationHandler(
       fromEither(_).mapLeft(queryError =>
         Failure.encode({
           kind: "PERMANENT",
-          reason: `Query Error code=${queryError.code}`
+          reason: `Query Error ${queryError.code}=${queryError.body}`
         })
       )
     )

--- a/ContinueBonusActivation/handler.ts
+++ b/ContinueBonusActivation/handler.ts
@@ -19,6 +19,8 @@ import { BonusActivationModel } from "../models/bonus_activation";
 import { Failure } from "../utils/errors";
 import { makeStartBonusActivationOrchestratorId } from "../utils/orchestrators";
 
+import * as t from "io-ts";
+
 export const ContinueBonusActivationInput = t.type({
   applicantFiscalCode: FiscalCode,
   bonusId: BonusCode

--- a/ContinueBonusActivation/index.ts
+++ b/ContinueBonusActivation/index.ts
@@ -5,8 +5,6 @@ import * as documentDbUtils from "io-functions-commons/dist/src/utils/documentdb
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import * as t from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
-import { FiscalCode } from "italia-ts-commons/lib/strings";
-import { BonusCode } from "../generated/definitions/BonusCode";
 import {
   BONUS_ACTIVATION_COLLECTION_NAME,
   BonusActivationModel

--- a/ContinueBonusActivation/index.ts
+++ b/ContinueBonusActivation/index.ts
@@ -1,0 +1,72 @@
+import { AzureFunction, Context } from "@azure/functions";
+import * as df from "durable-functions";
+import { fromEither } from "fp-ts/lib/TaskEither";
+import * as documentDbUtils from "io-functions-commons/dist/src/utils/documentdb";
+import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
+import * as t from "io-ts";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+import { FiscalCode } from "italia-ts-commons/lib/strings";
+import { BonusCode } from "../generated/definitions/BonusCode";
+import {
+  BONUS_ACTIVATION_COLLECTION_NAME,
+  BonusActivationModel
+} from "../models/bonus_activation";
+import { documentClient } from "../utils/cosmosdb";
+import { Failure } from "../utils/errors";
+import { ContinueBonusActivationHandler } from "./handler";
+
+const cosmosDbName = getRequiredStringEnv("COSMOSDB_BONUS_DATABASE_NAME");
+
+const documentDbDatabaseUrl = documentDbUtils.getDatabaseUri(cosmosDbName);
+const bonusActivationCollectionUrl = documentDbUtils.getCollectionUri(
+  documentDbDatabaseUrl,
+  BONUS_ACTIVATION_COLLECTION_NAME
+);
+
+const bonusActivationModel = new BonusActivationModel(
+  documentClient,
+  bonusActivationCollectionUrl
+);
+
+export const ContinueBonusActivationInput = t.type({
+  applicantFiscalCode: FiscalCode,
+  bonusId: BonusCode
+});
+
+/**
+ * Reads from a queue the tuple (bonusId, fiscalCode)
+ * then try to start the orchestrator to activate the bonus.
+ */
+const index: AzureFunction = (
+  context: Context,
+  message: unknown
+): Promise<Failure | string> => {
+  return fromEither(ContinueBonusActivationInput.decode(message))
+    .mapLeft(errs =>
+      Failure.encode({
+        kind: "PERMANENT",
+        reason: `Cannot decode input: ${readableReport(errs)}`
+      })
+    )
+    .chain(({ bonusId, applicantFiscalCode }) =>
+      ContinueBonusActivationHandler(
+        df.getClient(context),
+        bonusActivationModel,
+        applicantFiscalCode,
+        bonusId
+      )
+    )
+    .fold<Failure | string>(err => {
+      context.log.error(
+        `ContinueBonusActivation|${err.kind}_ERROR=${err.reason}`
+      );
+      if (err.kind === "TRANSIENT") {
+        // Trigger a retry in case of temporary failures
+        throw new Error(err.reason);
+      }
+      return err;
+    }, t.identity)
+    .run();
+};
+
+export default index;

--- a/ContinueBonusActivation/index.ts
+++ b/ContinueBonusActivation/index.ts
@@ -10,7 +10,7 @@ import {
   BonusActivationModel
 } from "../models/bonus_activation";
 import { documentClient } from "../utils/cosmosdb";
-import { Failure } from "../utils/errors";
+import { Failure, TransientFailure } from "../utils/errors";
 import {
   ContinueBonusActivationHandler,
   ContinueBonusActivationInput
@@ -56,7 +56,7 @@ const index: AzureFunction = (
       context.log.error(
         `ContinueBonusActivation|${err.kind}_ERROR=${err.reason}`
       );
-      if (err.kind === "TRANSIENT") {
+      if (TransientFailure.is(err)) {
         // Trigger a retry in case of temporary failures
         throw new Error(err.reason);
       }

--- a/ContinueBonusActivation/index.ts
+++ b/ContinueBonusActivation/index.ts
@@ -13,7 +13,10 @@ import {
 } from "../models/bonus_activation";
 import { documentClient } from "../utils/cosmosdb";
 import { Failure } from "../utils/errors";
-import { ContinueBonusActivationHandler } from "./handler";
+import {
+  ContinueBonusActivationHandler,
+  ContinueBonusActivationInput
+} from "./handler";
 
 const cosmosDbName = getRequiredStringEnv("COSMOSDB_BONUS_DATABASE_NAME");
 
@@ -27,11 +30,6 @@ const bonusActivationModel = new BonusActivationModel(
   documentClient,
   bonusActivationCollectionUrl
 );
-
-export const ContinueBonusActivationInput = t.type({
-  applicantFiscalCode: FiscalCode,
-  bonusId: BonusCode
-});
 
 /**
  * Reads from a queue the tuple (bonusId, fiscalCode)

--- a/EligibilityCheck/__tests__/handler.test.ts
+++ b/EligibilityCheck/__tests__/handler.test.ts
@@ -58,7 +58,7 @@ describe("EligibilityCheckHandler", () => {
   });
   it("should returns ResponseSuccessRedirectToResource if EligibilityCheckOrchestrator starts successfully", async () => {
     mockStartNew.mockImplementationOnce(async (_, __, ___) => {
-      return;
+      return "instanceId";
     });
 
     const handler = EligibilityCheckHandler();

--- a/EligibilityCheck/__tests__/handler.test.ts
+++ b/EligibilityCheck/__tests__/handler.test.ts
@@ -12,13 +12,6 @@ import {
 } from "../../utils/orchestrators";
 import { EligibilityCheckHandler } from "../handler";
 
-jest.mock("applicationinsights", () => ({
-  defaultClient: {
-    trackEvent: jest.fn(),
-    trackException: jest.fn()
-  }
-}));
-
 // implement temporary mockGetStatus
 const simulateOrchestratorIsRunning = (forOrchestratorId: string) => {
   mockGetStatus.mockImplementation(async (orchestratorId: string) =>

--- a/EligibilityCheckOrchestrator/__tests__/index.test.ts
+++ b/EligibilityCheckOrchestrator/__tests__/index.test.ts
@@ -10,13 +10,6 @@ import { SiNoTypeEnum } from "../../generated/definitions/SiNoType";
 import { toApiEligibilityCheckFromDSU } from "../../utils/conversions";
 import { handler } from "../index";
 
-jest.mock("applicationinsights", () => ({
-  defaultClient: {
-    trackEvent: jest.fn(),
-    trackException: jest.fn()
-  }
-}));
-
 const deleteEligibilityCheckActivityResult: DeleteEligibilityCheckActivityResult = {
   kind: "SUCCESS"
 };

--- a/SendBonusActivationActivity/__tests__/handler.test.ts
+++ b/SendBonusActivationActivity/__tests__/handler.test.ts
@@ -15,13 +15,6 @@ import {
   SendBonusActivationSuccess
 } from "../handler";
 
-jest.mock("applicationinsights", () => ({
-  defaultClient: {
-    trackEvent: jest.fn(),
-    trackException: jest.fn()
-  }
-}));
-
 describe("SendBonusActivationHandler", () => {
   it("should handle an invalid input", async () => {
     const mockADEClient = {

--- a/StartBonusActivation/__tests__/handler.test.ts
+++ b/StartBonusActivation/__tests__/handler.test.ts
@@ -91,7 +91,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -107,7 +108,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -122,7 +124,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -135,7 +138,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -150,7 +154,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -165,7 +170,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -180,7 +186,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -198,7 +205,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -221,7 +229,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -237,7 +246,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -253,7 +263,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -269,7 +280,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -286,7 +298,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);
@@ -298,7 +311,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     await handler(context, aFiscalCode);
@@ -311,7 +325,8 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel
+      mockEligibilityCheckModel,
+      isBonusActivationEnabled
     );
 
     const response = await handler(context, aFiscalCode);

--- a/StartBonusActivation/__tests__/handler.test.ts
+++ b/StartBonusActivation/__tests__/handler.test.ts
@@ -11,6 +11,7 @@ import {
   mockStatusRunning
 } from "../../__mocks__/durable-functions";
 import {
+  aBonusId,
   aEligibilityCheckSuccessEligibleExpired,
   aEligibilityCheckSuccessEligibleValid,
   aEligibilityCheckSuccessIneligible,
@@ -77,6 +78,8 @@ const aFiscalCode = "AAABBB80A01C123D" as FiscalCode;
 describe("StartBonusActivationHandler", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // tslint:disable-next-line: no-object-mutation
+    context.bindings = {};
   });
 
   afterEach(() => {
@@ -96,6 +99,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(response.kind).toBe("IResponseErrorForbiddenNotAuthorized");
   });
@@ -112,6 +116,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(response.kind).toBe("IResponseSuccessAccepted");
   });
@@ -127,6 +132,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(response.kind).toBe("IResponseErrorGone");
   });
@@ -140,6 +146,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(response.kind).toBe("IResponseErrorForbiddenNotAuthorized");
   });
@@ -155,6 +162,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(response.kind).toBe("IResponseErrorForbiddenNotAuthorized");
   });
@@ -170,6 +178,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(response.kind).toBe("IResponseErrorInternal");
   });
@@ -185,6 +194,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(response.kind).toBe("IResponseErrorInternal");
   });
@@ -203,6 +213,10 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toEqual({
+      applicantFiscalCode: aFiscalCode,
+      bonusId: aBonusId
+    });
 
     // the first attempt failed, so it's called twice
     expect(mockBonusActivationCreate).toHaveBeenCalledTimes(2);
@@ -226,6 +240,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(mockBonusActivationCreate).toHaveBeenCalledTimes(1);
     expect(response.kind).toBe("IResponseErrorInternal");
@@ -242,6 +257,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(mockBonusActivationCreate).toHaveBeenCalledTimes(1);
     expect(response.kind).toBe("IResponseErrorInternal");
@@ -260,6 +276,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(response.kind).toBe("IResponseErrorConflict");
   });
@@ -275,6 +292,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(response.kind).toBe("IResponseErrorInternal");
   });
@@ -291,6 +309,7 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
     expect(mockBonusLeaseDeleteOneById).toHaveBeenCalledTimes(1);
     expect(response.kind).toBe("IResponseErrorInternal");
   });
@@ -307,11 +326,12 @@ describe("StartBonusActivationHandler", () => {
     );
 
     await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toBeUndefined();
 
     expect(mockBonusLeaseDeleteOneById).not.toHaveBeenCalled();
   });
 
-  it("should return the reference to the executed orchestrator", async () => {
+  it("should set queue bindings in case bonus creation succeed", async () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
@@ -319,6 +339,10 @@ describe("StartBonusActivationHandler", () => {
     );
 
     const response = await handler(context, aFiscalCode);
+    expect(context.bindings.bonusActivation).toEqual({
+      applicantFiscalCode: aFiscalCode,
+      bonusId: aBonusId
+    });
     expect(response.kind).toBe("IResponseSuccessRedirectToResource");
   });
 });

--- a/StartBonusActivation/__tests__/handler.test.ts
+++ b/StartBonusActivation/__tests__/handler.test.ts
@@ -73,6 +73,7 @@ const mockBonusLeaseModel = ({
 
 const aFiscalCode = "AAABBB80A01C123D" as FiscalCode;
 
+// tslint:disable-next-line: no-big-function
 describe("StartBonusActivationHandler", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -91,8 +92,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -108,8 +108,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -124,8 +123,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -138,8 +136,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -154,8 +151,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -170,8 +166,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -186,8 +181,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -205,8 +199,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -229,8 +222,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -246,8 +238,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -263,8 +254,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -280,8 +270,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -298,8 +287,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);
@@ -311,8 +299,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     await handler(context, aFiscalCode);
@@ -325,8 +312,7 @@ describe("StartBonusActivationHandler", () => {
     const handler = StartBonusActivationHandler(
       mockBonusActivationModel,
       mockBonusLeaseModel,
-      mockEligibilityCheckModel,
-      isBonusActivationEnabled
+      mockEligibilityCheckModel
     );
 
     const response = await handler(context, aFiscalCode);

--- a/StartBonusActivation/__tests__/handler.test.ts
+++ b/StartBonusActivation/__tests__/handler.test.ts
@@ -27,13 +27,6 @@ import {
 } from "../../utils/orchestrators";
 import { StartBonusActivationHandler } from "../handler";
 
-jest.mock("applicationinsights", () => ({
-  defaultClient: {
-    trackEvent: jest.fn(),
-    trackException: jest.fn()
-  }
-}));
-
 // implement temporary mockGetStatus
 const simulateOrchestratorIsRunning = (forOrchestratorId: string) => {
   mockGetStatus.mockImplementation(async (orchestratorId: string) =>

--- a/StartBonusActivation/__tests__/handler.test.ts
+++ b/StartBonusActivation/__tests__/handler.test.ts
@@ -279,23 +279,6 @@ describe("StartBonusActivationHandler", () => {
     expect(response.kind).toBe("IResponseErrorInternal");
   });
 
-  it("should relase the lock if the orchestrator fails to start", async () => {
-    mockStartNew.mockImplementationOnce(async () => {
-      throw new Error();
-    });
-
-    const handler = StartBonusActivationHandler(
-      mockBonusActivationModel,
-      mockBonusLeaseModel,
-      mockEligibilityCheckModel
-    );
-
-    const response = await handler(context, aFiscalCode);
-
-    expect(mockBonusLeaseDeleteOneById).toHaveBeenCalledTimes(1);
-    expect(response.kind).toBe("IResponseErrorInternal");
-  });
-
   it("should relase the lock if the bonus creation fails", async () => {
     mockBonusActivationCreate.mockImplementationOnce(async _ => {
       throw new Error("any error");
@@ -310,19 +293,6 @@ describe("StartBonusActivationHandler", () => {
     const response = await handler(context, aFiscalCode);
     expect(mockBonusLeaseDeleteOneById).toHaveBeenCalledTimes(1);
     expect(response.kind).toBe("IResponseErrorInternal");
-  });
-
-  it("should not relase the lock if the orchestrator starts", async () => {
-    const handler = StartBonusActivationHandler(
-      mockBonusActivationModel,
-      mockBonusLeaseModel,
-      mockEligibilityCheckModel
-    );
-
-    await handler(context, aFiscalCode);
-
-    expect(mockStartNew).toHaveBeenCalledTimes(1);
-    expect(mockBonusLeaseDeleteOneById).not.toHaveBeenCalled();
   });
 
   it("should not relase the lock when fails to acquire the lock", async () => {

--- a/StartBonusActivation/function.json
+++ b/StartBonusActivation/function.json
@@ -17,6 +17,13 @@
       "name": "starter",
       "type": "durableClient",
       "direction": "in"
+    },
+    {
+      "type": "queue",
+      "direction": "out",
+      "name": "bonusActivation",
+      "queueName": "bonusactivations",
+      "connection": "BONUS_STORAGE_CONNECTION_STRING"
     }
   ],
   "scriptFile": "../dist/StartBonusActivation/index.js"

--- a/StartBonusActivation/handler.ts
+++ b/StartBonusActivation/handler.ts
@@ -56,14 +56,13 @@ import {
 } from "../utils/orchestrators";
 
 import { defaultClient } from "applicationinsights";
-import { io } from "fp-ts/lib/IO";
 import {
   fromQueryEither,
   QueryError
 } from "io-functions-commons/dist/src/utils/documentdb";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { Millisecond } from "italia-ts-commons/lib/units";
-import { ContinueBonusActivationInput } from "../ContinueBonusActivation";
+import { ContinueBonusActivationInput } from "../ContinueBonusActivation/handler";
 import { BonusActivation as ApiBonusActivation } from "../generated/definitions/BonusActivation";
 import { BonusActivationWithFamilyUID } from "../generated/models/BonusActivationWithFamilyUID";
 import { FamilyUID } from "../generated/models/FamilyUID";

--- a/StartBonusActivation/handler.ts
+++ b/StartBonusActivation/handler.ts
@@ -6,7 +6,6 @@ import * as express from "express";
 import { left, right, toError } from "fp-ts/lib/Either";
 import {
   fromEither,
-  fromIO,
   TaskEither,
   taskEither,
   tryCatch

--- a/StartBonusActivation/handler.ts
+++ b/StartBonusActivation/handler.ts
@@ -352,13 +352,8 @@ export function StartBonusActivationHandler(
           familyUID
         }))
       )
-      .chain<BonusActivationWithFamilyUID>(({ dsu, familyUID }) => {
-        return createBonusActivation(
-          bonusActivationModel,
-          fiscalCode,
-          familyUID,
-          dsu
-        )
+      .chain<BonusActivationWithFamilyUID>(({ dsu, familyUID }) =>
+        createBonusActivation(bonusActivationModel, fiscalCode, familyUID, dsu)
           .map(bonusActivation => {
             // Send the (bonusId, applicantFiscalCode) to the bonus activations queue
             // in order to be processed later (asynchronously)
@@ -389,8 +384,8 @@ export function StartBonusActivationHandler(
               );
             },
             bonusActivation => taskEither.of(bonusActivation)
-          );
-      })
+          )
+      )
       .chain(bonusActivation =>
         fromEither(toApiBonusActivation(bonusActivation)).mapLeft(err =>
           ResponseErrorInternal(

--- a/StartBonusActivation/handler.ts
+++ b/StartBonusActivation/handler.ts
@@ -353,16 +353,12 @@ export function StartBonusActivationHandler(
         }))
       )
       .chain<BonusActivationWithFamilyUID>(({ dsu, familyUID }) => {
-        return taskEither
-          .of<StartBonusActivationResponse, void>(void 0)
-          .chain(_ =>
-            createBonusActivation(
-              bonusActivationModel,
-              fiscalCode,
-              familyUID,
-              dsu
-            )
-          )
+        return createBonusActivation(
+          bonusActivationModel,
+          fiscalCode,
+          familyUID,
+          dsu
+        )
           .map(bonusActivation => {
             // Send the (bonusId, applicantFiscalCode) to the bonus activations queue
             // in order to be processed later (asynchronously)

--- a/__mocks__/applicationinsights.ts
+++ b/__mocks__/applicationinsights.ts
@@ -1,0 +1,4 @@
+export const defaultClient = {
+  trackEvent: jest.fn(),
+  trackException: jest.fn()
+};

--- a/__mocks__/durable-functions.ts
+++ b/__mocks__/durable-functions.ts
@@ -11,7 +11,9 @@ export const mockStatusCompleted = {
 
 export const OrchestrationRuntimeStatus = df.OrchestrationRuntimeStatus;
 
-export const mockStartNew = jest.fn((_, __, ___) => Promise.resolve());
+export const mockStartNew = jest.fn((_, __, ___) =>
+  Promise.resolve("instanceId")
+);
 export const mockGetStatus = jest
   .fn()
   .mockImplementation(async () => mockStatusCompleted);

--- a/__mocks__/durable-functions.ts
+++ b/__mocks__/durable-functions.ts
@@ -30,6 +30,7 @@ export const orchestrator = jest.fn();
 export const RetryOptions = jest.fn(() => ({}));
 
 export const context = ({
+  bindings: {},
   log: {
     // tslint:disable-next-line: no-console
     error: jest.fn().mockImplementation(console.log),

--- a/host.json
+++ b/host.json
@@ -6,9 +6,9 @@
     }
   },
   "extensions": {
-      "http": {
-        "routePrefix": ""
-      },
+    "http": {
+      "routePrefix": ""
+    },
 
     "durableTask": {
       "hubName": "%SLOT_TASK_HUBNAME%",
@@ -19,6 +19,15 @@
         "traceInputsAndOutputs": false,
         "traceReplayEvents": false
       }
+    },
+
+    "queues": {
+      "maxPollingInterval": "00:00:02",
+      "visibilityTimeout" : "00:00:30",
+      "batchSize": 16,
+      "maxDequeueCount": 5,
+      "newBatchThreshold": 8
     }
+
   }
 }

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -164,6 +164,7 @@ paths:
           description: Service unavailable.
           schema:
             $ref: "#/definitions/ProblemJson"
+
 parameters:
   FiscalCode:
     name: fiscalcode

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -1,0 +1,21 @@
+import * as t from "io-ts";
+
+const FailureBase = t.partial({
+  reason: t.string
+});
+
+export const TransientFailure = t.interface({
+  kind: t.literal("TRANSIENT")
+});
+export type TransientFailure = t.TypeOf<typeof TransientFailure>;
+
+export const PermanentFailure = t.interface({
+  kind: t.literal("PERMANENT")
+});
+export type PermanentFailure = t.TypeOf<typeof PermanentFailure>;
+
+export const Failure = t.intersection([
+  FailureBase,
+  t.union([TransientFailure, PermanentFailure])
+]);
+export type Failure = t.TypeOf<typeof Failure>;


### PR DESCRIPTION
Draft since it lacks tests

This changes the current bonus activation flow from 

controller -> startNew(orchestrator) to
controller -> enqueue(bonusid) <- read from queue <- startNew(orchestrator)

so we have a new function that dequeue items enqued from StartBonusActivation controller.

This function may be shut down or activated at will using common settings (environment variables) -> `AzureWebJobs.ContinueBonusActivation.Disabled=true`

