### PR TITLE
[#173432107] Try fix asynchronous running check on bonus activation

### DIFF
--- a/ContinueBonusActivation/__tests__/handler.test.ts
+++ b/ContinueBonusActivation/__tests__/handler.test.ts
@@ -1,7 +1,11 @@
 import * as df from "durable-functions";
 import { isLeft, isRight, left, right } from "fp-ts/lib/Either";
 import { none, some } from "fp-ts/lib/Option";
-import { context, mockStartNew } from "../../__mocks__/durable-functions";
+import {
+  context,
+  mockRaiseEvent,
+  mockStartNew
+} from "../../__mocks__/durable-functions";
 import {
   aBonusActivation,
   aBonusActivationWithFamilyUID,
@@ -106,8 +110,8 @@ describe("ContinueBonusActivation", () => {
     }
   });
 
-  it("should return a transient error if the orchestrator throw", async () => {
-    mockStartNew.mockImplementationOnce(async () => {
+  it("should return a transient error if raise event throws", async () => {
+    mockRaiseEvent.mockImplementationOnce(async () => {
       throw new Error("foobar");
     });
     const mockBonusActivationkModel = ({
@@ -160,7 +164,7 @@ describe("ContinueBonusActivation", () => {
 
     expect(isRight(response)).toBeTruthy();
     if (isRight(response)) {
-      expect(response.value).toEqual("instanceId");
+      expect(response.value).toEqual(true);
     }
   });
 });

--- a/ContinueBonusActivation/handler.ts
+++ b/ContinueBonusActivation/handler.ts
@@ -9,7 +9,10 @@ import {
 } from "fp-ts/lib/TaskEither";
 import { FiscalCode } from "italia-ts-commons/lib/strings";
 
-import { ContinueEventInput } from "../StartBonusActivationOrchestrator/handler";
+import {
+  CONTINUE_BONUS_ACTIVATION_EVENT_NAME,
+  ContinueEventInput
+} from "../StartBonusActivationOrchestrator/handler";
 
 import { BonusCode } from "../generated/definitions/BonusCode";
 import { BonusActivationWithFamilyUID } from "../generated/models/BonusActivationWithFamilyUID";
@@ -84,7 +87,7 @@ export function ContinueBonusActivationHandler(
               makeStartBonusActivationOrchestratorId(
                 bonusActivation.applicantFiscalCode
               ),
-              "Continue",
+              CONTINUE_BONUS_ACTIVATION_EVENT_NAME,
               ContinueEventInput.encode({ bonusActivation })
             ),
           err =>

--- a/ContinueBonusActivation/index.ts
+++ b/ContinueBonusActivation/index.ts
@@ -36,7 +36,7 @@ const bonusActivationModel = new BonusActivationModel(
 const index: AzureFunction = (
   context: Context,
   message: unknown
-): Promise<Failure | string> => {
+): Promise<Failure | void> => {
   return fromEither(ContinueBonusActivationInput.decode(message))
     .mapLeft(errs =>
       Failure.encode({
@@ -52,7 +52,7 @@ const index: AzureFunction = (
         bonusId
       )
     )
-    .fold<Failure | string>(err => {
+    .fold<Failure | void>(err => {
       context.log.error(
         `ContinueBonusActivation|${err.kind}_ERROR=${err.reason}`
       );

--- a/ContinueBonusActivation/index.ts
+++ b/ContinueBonusActivation/index.ts
@@ -36,7 +36,7 @@ const bonusActivationModel = new BonusActivationModel(
 const index: AzureFunction = (
   context: Context,
   message: unknown
-): Promise<Failure | void> => {
+): Promise<Failure | true> => {
   return fromEither(ContinueBonusActivationInput.decode(message))
     .mapLeft(errs =>
       Failure.encode({
@@ -52,7 +52,7 @@ const index: AzureFunction = (
         bonusId
       )
     )
-    .fold<Failure | void>(err => {
+    .fold<Failure | true>(err => {
       context.log.error(
         `ContinueBonusActivation|${err.kind}_ERROR=${err.reason}`
       );

--- a/StartBonusActivationOrchestrator/handler.ts
+++ b/StartBonusActivationOrchestrator/handler.ts
@@ -21,6 +21,8 @@ import { toHash } from "../utils/hash";
 import { MESSAGES } from "../utils/messages";
 import { retryOptions } from "../utils/retryPolicy";
 
+export const CONTINUE_BONUS_ACTIVATION_EVENT_NAME = "ContinueBonusActivation";
+
 export const OrchestratorInput = t.interface({
   bonusId: BonusCode
 });
@@ -64,7 +66,7 @@ export const getStartBonusActivationOrchestratorHandler = (
 
     // Get bonus activation model object from event input
     const undecodedBonusActivation = yield context.df.waitForExternalEvent(
-      "Continue"
+      CONTINUE_BONUS_ACTIVATION_EVENT_NAME
     );
     const errorOrContinueEventInput = ContinueEventInput.decode(
       undecodedBonusActivation

--- a/__mocks__/durable-functions.ts
+++ b/__mocks__/durable-functions.ts
@@ -21,8 +21,11 @@ export const mockTerminate = jest.fn(async (_, __) => {
   return;
 });
 
+export const mockRaiseEvent = jest.fn(async (_, __, ___) => void 0);
+
 export const getClient = jest.fn(() => ({
   getStatus: mockGetStatus,
+  raiseEvent: mockRaiseEvent,
   startNew: mockStartNew,
   terminate: mockTerminate
 }));


### PR DESCRIPTION
Reason: https://www.pivotaltracker.com/story/show/173432107

Summary: now that the Start Bonus Activation orchestrator runs sometime in the future _after_ the controller is called (with a POST to `/bonus/activations/{cf}`) the check for a running orchestrator fails: following POSTs to the same endpoint returns 409 Conflict and not 202 processing (even if the bonus is not ACTIVE yet)

This causes some issues:
1) The mobile app can't tell a 409 conflict from 202 processing
2) The mobile app can't get the bonus ID of the processing bonus
3) Edge case: a user may create more than one bonus in status PROCESSING; when the orchestrators will start later in time, as the instanceId is the same, the last run will override the previous one and all the bonuses but the last one will stuck in PROCESSING state

To try to fix I've reverted the former behaviour: the controller start the orchestrator immediately (so checks for running orchestrators will succeed and we can return the processing bonus ID to the app), then the orchestrator call `waitForExternalEvent` and pauses. Another function, ContinueStartBonusActivation dequeue messages and awake it calling `raiseEvent`

